### PR TITLE
added multi-threading to run_parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Now you can start the server with `tb RUN_PATH` and your python script that crea
 ## Parallel processing
 It is customary to run a function multiple times on different inputs (e.g., compute spectrograms from multiple audio
 recordings, apply some processing to all the images in a dataset, analyze each frame of a video, etc.).
-This can be done serially with a for loop, or in parallel over multiple cores.
+This can be done serially with a for loop, or in parallel over multiple cores, or using multiple threads (best for I/O operations on lots of files).
 Have a look at the example script [*run_parallel.py*](run_parallel.py).
 
 

--- a/run_parallel.py
+++ b/run_parallel.py
@@ -10,6 +10,7 @@ Paolo Bestagini
 import time
 from functools import partial
 from multiprocessing import Pool, cpu_count
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 from tqdm import tqdm
@@ -56,10 +57,18 @@ def main():
 
     # Close the pool
     pool.close()
+    
+    # Evaluate the function with multi-threading
+    # BEST TO USE for I/O operations on data
+    t = time.time()
+    with ThreadPoolExecutor(num_cpu) as p:
+        results_mthread = list(tqdm(p.map(fun_part, x_list), total=len(x_list), desc='Multi-threading')) # With wait-bar
+    t_mthread = time.time() - t
 
     # Print results
     print('Serial results:   {} [{:.2f} ms]'.format(result_series, t_series*1000))
     print('Parallel results: {} [{:.2f} ms]'.format(result_parallel, t_parallel*1000))
+    print('Multi-threading results: {} [{:.2f} ms]'.format(results_mthread, t_mthread*1000))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added an example on how to use multi-threading for parallel computations.
Multi-threading is preferrable sometimes since:
1. is lighter;
2. allows to run multiple threads wrt machine cores (no 1-1 correspondance);
3. doesn't lock resources (best for I/O operations on a lots of data, e.g., the DFDC frames).

Tested on my laptop (screenshot below)
![image](https://user-images.githubusercontent.com/16773532/141277102-755cdd2f-8cd3-48eb-a55e-1be9f02e9d88.png)
